### PR TITLE
XCH-23-DATATABLE-SLOT-VUE

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -18,6 +18,10 @@ export namespace Components {
         "disabled": boolean;
         "size": number;
     }
+    interface EfDataTable {
+        "data": { [key: string]: string | number }[];
+        "headers": { text: string; value: string; slot?: (item: { [key: string]: string | number }) => JSX.Element }[];
+    }
     interface EfDropdown {
         "disabled": boolean;
         "errorMessage": string;
@@ -40,10 +44,6 @@ export namespace Components {
         "name": string;
         "rol": string;
     }
-    interface PrDataTable {
-        "data": { [key: string]: string | number }[];
-        "headers": { text: string; value: string; slot?: (item: { [key: string]: string | number }) => JSX.Element }[];
-    }
 }
 declare global {
     interface HTMLEfButtonElement extends Components.EfButton, HTMLStencilElement {
@@ -57,6 +57,12 @@ declare global {
     var HTMLEfCheckboxElement: {
         prototype: HTMLEfCheckboxElement;
         new (): HTMLEfCheckboxElement;
+    };
+    interface HTMLEfDataTableElement extends Components.EfDataTable, HTMLStencilElement {
+    }
+    var HTMLEfDataTableElement: {
+        prototype: HTMLEfDataTableElement;
+        new (): HTMLEfDataTableElement;
     };
     interface HTMLEfDropdownElement extends Components.EfDropdown, HTMLStencilElement {
     }
@@ -76,19 +82,13 @@ declare global {
         prototype: HTMLEfProfileRolElement;
         new (): HTMLEfProfileRolElement;
     };
-    interface HTMLPrDataTableElement extends Components.PrDataTable, HTMLStencilElement {
-    }
-    var HTMLPrDataTableElement: {
-        prototype: HTMLPrDataTableElement;
-        new (): HTMLPrDataTableElement;
-    };
     interface HTMLElementTagNameMap {
         "ef-button": HTMLEfButtonElement;
         "ef-checkbox": HTMLEfCheckboxElement;
+        "ef-data-table": HTMLEfDataTableElement;
         "ef-dropdown": HTMLEfDropdownElement;
         "ef-input": HTMLEfInputElement;
         "ef-profile-rol": HTMLEfProfileRolElement;
-        "pr-data-table": HTMLPrDataTableElement;
     }
 }
 declare namespace LocalJSX {
@@ -105,6 +105,10 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "onEvent"?: (event: CustomEvent<any>) => void;
         "size"?: number;
+    }
+    interface EfDataTable {
+        "data"?: { [key: string]: string | number }[];
+        "headers"?: { text: string; value: string; slot?: (item: { [key: string]: string | number }) => JSX.Element }[];
     }
     interface EfDropdown {
         "disabled"?: boolean;
@@ -130,17 +134,13 @@ declare namespace LocalJSX {
         "name"?: string;
         "rol"?: string;
     }
-    interface PrDataTable {
-        "data"?: { [key: string]: string | number }[];
-        "headers"?: { text: string; value: string; slot?: (item: { [key: string]: string | number }) => JSX.Element }[];
-    }
     interface IntrinsicElements {
         "ef-button": EfButton;
         "ef-checkbox": EfCheckbox;
+        "ef-data-table": EfDataTable;
         "ef-dropdown": EfDropdown;
         "ef-input": EfInput;
         "ef-profile-rol": EfProfileRol;
-        "pr-data-table": PrDataTable;
     }
 }
 export { LocalJSX as JSX };
@@ -149,10 +149,10 @@ declare module "@stencil/core" {
         interface IntrinsicElements {
             "ef-button": LocalJSX.EfButton & JSXBase.HTMLAttributes<HTMLEfButtonElement>;
             "ef-checkbox": LocalJSX.EfCheckbox & JSXBase.HTMLAttributes<HTMLEfCheckboxElement>;
+            "ef-data-table": LocalJSX.EfDataTable & JSXBase.HTMLAttributes<HTMLEfDataTableElement>;
             "ef-dropdown": LocalJSX.EfDropdown & JSXBase.HTMLAttributes<HTMLEfDropdownElement>;
             "ef-input": LocalJSX.EfInput & JSXBase.HTMLAttributes<HTMLEfInputElement>;
             "ef-profile-rol": LocalJSX.EfProfileRol & JSXBase.HTMLAttributes<HTMLEfProfileRolElement>;
-            "pr-data-table": LocalJSX.PrDataTable & JSXBase.HTMLAttributes<HTMLPrDataTableElement>;
         }
     }
 }

--- a/src/components/ef-data-table/ef-data-table.tsx
+++ b/src/components/ef-data-table/ef-data-table.tsx
@@ -1,32 +1,25 @@
 import { Component, h, Host, Prop } from '@stencil/core';
-
-@Component({
-  tag: 'ef-data-table',
-  styleUrl: 'ef-data-table.css',
-})
+@Component({ tag: 'ef-data-table', styleUrl: 'ef-data-table.css', shadow: true })
 export class PrDataTable {
-  @Prop() headers: { text: string; value: string; slot?: (item: { [key: string]: string | number }) => JSX.Element }[]
-  @Prop() data: { [key: string]: string | number }[]
-
-  renderRowData(dataRow: { [key: string]: string | number }) {
+  @Prop() headers: { text: string; value: string; slot?: (item: { [key: string]: string | number }) => JSX.Element }[];
+  @Prop() data: { [key: string]: string | number }[];
+  renderRowData(dataRow: { [key: string]: string | number }, key: number) {
     return (
       <tr class="border-table">
         {this.headers.map(header => {
-          if(header.slot){
+          if (header.slot) {
+            return <td>{header.slot(dataRow)}</td>;
+          } else {
             return (
-              <td>{header.slot(dataRow)}</td>
-            )
-          }
-          else{
-            return (
-              <td>{dataRow[header.value]}</td>
-            )
+              <td>
+                <slot name={`${dataRow[header.value]}${key}`}>{dataRow[header.value]}</slot>
+              </td>
+            );
           }
         })}
       </tr>
     );
   }
-
   render() {
     return (
       <Host>
@@ -38,7 +31,7 @@ export class PrDataTable {
               ))}
             </tr>
           </thead>
-          <tbody class="table-body">{this.data.map(item => this.renderRowData(item))}</tbody>
+          <tbody class="table-body">{this.data.map((item, key) => this.renderRowData(item, key))}</tbody>
         </table>
       </Host>
     );

--- a/src/components/ef-data-table/readme.md
+++ b/src/components/ef-data-table/readme.md
@@ -1,0 +1,18 @@
+# ef-data-table
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property  | Attribute | Description | Type                                                                                                 | Default     |
+| --------- | --------- | ----------- | ---------------------------------------------------------------------------------------------------- | ----------- |
+| `data`    | --        |             | `{ [key: string]: string \| number; }[]`                                                             | `undefined` |
+| `headers` | --        |             | `{ text: string; value: string; slot?: (item: { [key: string]: string \| number; }) => Element; }[]` | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/index.html
+++ b/src/index.html
@@ -32,7 +32,8 @@
 
 <body>
   <div style="display:flex;flex-direction:row;align-items:center;justify-content:space-around;">
-    <ef-data-table></ef-data-table>
+    <ef-data-table>
+    </ef-data-table>
   </div>
 </body>
 


### PR DESCRIPTION
link card: XCH-23 [https://thecoderhouse.atlassian.net/browse/XCH-23]

Descripcion: se realizo la actualizacion de componente de stencil de datable, obteniendo las herramientas de slots para vue 3, dejando en funcionamiento slots tanto para vue como para react de la respectiva tabla, independientemente de cuantos props headers reciba o items en data reciba.

Como probar: 
-repositorio every-framework-components:  rama ->XCH-23-DATATABLE-PLUS-MODIFICATE
-npm i && npm run build
-npm run start