### PR TITLE
XCH-110-TEMPLATE-SECCION-ADMIN Y XCH-111-COMPONENT-RIGHT-BAR

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -49,6 +49,13 @@ export namespace Components {
         "modal": boolean;
         "width": string;
     }
+    interface EfModalRight {
+        "showModal": boolean;
+        "width": string;
+    }
+    interface EfTemplateAdmin {
+        "showModal": boolean;
+    }
 }
 declare global {
     interface HTMLEfButtonElement extends Components.EfButton, HTMLStencilElement {
@@ -93,6 +100,18 @@ declare global {
         prototype: HTMLEfModalElement;
         new (): HTMLEfModalElement;
     };
+    interface HTMLEfModalRightElement extends Components.EfModalRight, HTMLStencilElement {
+    }
+    var HTMLEfModalRightElement: {
+        prototype: HTMLEfModalRightElement;
+        new (): HTMLEfModalRightElement;
+    };
+    interface HTMLEfTemplateAdminElement extends Components.EfTemplateAdmin, HTMLStencilElement {
+    }
+    var HTMLEfTemplateAdminElement: {
+        prototype: HTMLEfTemplateAdminElement;
+        new (): HTMLEfTemplateAdminElement;
+    };
     interface HTMLElementTagNameMap {
         "ef-button": HTMLEfButtonElement;
         "ef-card-info": HTMLEfCardInfoElement;
@@ -101,6 +120,8 @@ declare global {
         "ef-dropdown": HTMLEfDropdownElement;
         "ef-input": HTMLEfInputElement;
         "ef-modal": HTMLEfModalElement;
+        "ef-modal-right": HTMLEfModalRightElement;
+        "ef-template-admin": HTMLEfTemplateAdminElement;
     }
 }
 declare namespace LocalJSX {
@@ -151,6 +172,13 @@ declare namespace LocalJSX {
         "modal"?: boolean;
         "width"?: string;
     }
+    interface EfModalRight {
+        "showModal"?: boolean;
+        "width"?: string;
+    }
+    interface EfTemplateAdmin {
+        "showModal"?: boolean;
+    }
     interface IntrinsicElements {
         "ef-button": EfButton;
         "ef-card-info": EfCardInfo;
@@ -159,6 +187,8 @@ declare namespace LocalJSX {
         "ef-dropdown": EfDropdown;
         "ef-input": EfInput;
         "ef-modal": EfModal;
+        "ef-modal-right": EfModalRight;
+        "ef-template-admin": EfTemplateAdmin;
     }
 }
 export { LocalJSX as JSX };
@@ -172,6 +202,8 @@ declare module "@stencil/core" {
             "ef-dropdown": LocalJSX.EfDropdown & JSXBase.HTMLAttributes<HTMLEfDropdownElement>;
             "ef-input": LocalJSX.EfInput & JSXBase.HTMLAttributes<HTMLEfInputElement>;
             "ef-modal": LocalJSX.EfModal & JSXBase.HTMLAttributes<HTMLEfModalElement>;
+            "ef-modal-right": LocalJSX.EfModalRight & JSXBase.HTMLAttributes<HTMLEfModalRightElement>;
+            "ef-template-admin": LocalJSX.EfTemplateAdmin & JSXBase.HTMLAttributes<HTMLEfTemplateAdminElement>;
         }
     }
 }

--- a/src/components/ef-modal-right/ef-modal-right.css
+++ b/src/components/ef-modal-right/ef-modal-right.css
@@ -1,0 +1,42 @@
+:host {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+}
+.modal-right {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  border-radius: 18px;
+  background-color: white;
+}
+
+@media only screen and (max-width: 600px) {
+  .modal-right {
+    top: 0;
+    left: 0;
+    position: fixed;
+    height: 100vh;
+    width: 100vw;
+    border-radius: 0px;
+    z-index: 999;
+  }
+  .modal-right-open {
+    -webkit-transform: translate3d(0px, 0px, 0px);
+    transform: translate3d(0px, 0px, 0px);
+    transition: all 0.5s ease 0s;
+    -webkit-transition: all 0.5s ease 0s;
+  }
+  .modal-right-close {
+    -webkit-transform: translate3d(100%, 0px, 0px);
+    transform: translate3d(100%, 0px, 0px);
+    transition: all 0.5s ease 0s;
+    -webkit-transition: all 0.5s ease 0s;
+  }
+}

--- a/src/components/ef-modal-right/ef-modal-right.tsx
+++ b/src/components/ef-modal-right/ef-modal-right.tsx
@@ -1,0 +1,20 @@
+import { Component, Host, h, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'ef-modal-right',
+  styleUrl: 'ef-modal-right.css',
+  shadow: true,
+})
+export class EfModalRight {
+  @Prop() showModal: boolean = false;
+  @Prop() width: string;
+  render() {
+    return (
+      <Host>
+        <div class={this.showModal ? 'modal-right-open modal-right' : 'modal-right-close modal-right'} style={{ width: this.width }}>
+          <slot />
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/ef-modal-right/readme.md
+++ b/src/components/ef-modal-right/readme.md
@@ -1,0 +1,31 @@
+# ef-modal-right
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property    | Attribute    | Description | Type      | Default     |
+| ----------- | ------------ | ----------- | --------- | ----------- |
+| `showModal` | `show-modal` |             | `boolean` | `false`     |
+| `width`     | `width`      |             | `string`  | `undefined` |
+
+
+## Dependencies
+
+### Used by
+
+ - [ef-template-admin](../ef-template-admin)
+
+### Graph
+```mermaid
+graph TD;
+  ef-template-admin --> ef-modal-right
+  style ef-modal-right fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/ef-modal/ef-modal.css
+++ b/src/components/ef-modal/ef-modal.css
@@ -34,3 +34,8 @@
   justify-content: center;
   align-items: center;
 }
+.modal-right-open {
+  display: block;
+  width: 100%;
+  height: 100%;
+}

--- a/src/components/ef-template-admin/ef-template-admin.css
+++ b/src/components/ef-template-admin/ef-template-admin.css
@@ -1,0 +1,44 @@
+.admin-container {
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  height: 100%;
+  width: 100%;
+}
+
+.content-left {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 69%;
+  height: 100%;
+  border-radius: 18px;
+}
+.content-right {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 29%;
+  height: 100%;
+  border-radius: 18px;
+}
+@media only screen and (max-width: 900px) {
+  .content-right {
+    width: 39%;
+  }
+  .content-left {
+    width: 59%;
+  }
+}
+@media only screen and (max-width: 600px) {
+  .content-right {
+    width: 0%;
+  }
+  .content-left {
+    width: 98%;
+  }
+}

--- a/src/components/ef-template-admin/ef-template-admin.tsx
+++ b/src/components/ef-template-admin/ef-template-admin.tsx
@@ -1,0 +1,22 @@
+import { Component, h, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'ef-template-admin',
+  styleUrl: 'ef-template-admin.css',
+  shadow: true,
+})
+export class EfTemplateAdmin {
+  @Prop() showModal: boolean = false;
+  render() {
+    return (
+      <div class="admin-container">
+        <div class="content-left">
+          <slot name="content-left"></slot>
+        </div>
+        <ef-modal-right class="content-right" show-modal={this.showModal}>
+          <slot name="content-right"></slot>
+        </ef-modal-right>
+      </div>
+    );
+  }
+}

--- a/src/components/ef-template-admin/readme.md
+++ b/src/components/ef-template-admin/readme.md
@@ -1,0 +1,10 @@
+# ef-template-admin
+
+
+
+<!-- Auto Generated Below -->
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/ef-template-admin/readme.md
+++ b/src/components/ef-template-admin/readme.md
@@ -5,6 +5,26 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property    | Attribute    | Description | Type      | Default |
+| ----------- | ------------ | ----------- | --------- | ------- |
+| `showModal` | `show-modal` |             | `boolean` | `false` |
+
+
+## Dependencies
+
+### Depends on
+
+- [ef-modal-right](../ef-modal-right)
+
+### Graph
+```mermaid
+graph TD;
+  ef-template-admin --> ef-modal-right
+  style ef-template-admin fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/index.html
+++ b/src/index.html
@@ -30,14 +30,15 @@
   @import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@300;400;500;600;700&display=swap');
 </style>
 
-<body>
-  <div style="display:flex;flex-direction:row;align-items:center;justify-content:space-around;">
-    <ef-card-info title="hola" subtitle="hola"
-      image="https://depor.com/resizer/QPAATuRp3-QBEaLxuMFJ73ta92E=/1200x900/smart/filters:format(jpeg):quality(75)/cloudfront-us-east-1.images.arcpublishing.com/elcomercio/K4EGYRJM2VH5TAF5FKAPFLANJ4.jpg">
-    </ef-card-info>
-
-
-  </div>
+<body style="height: 98vh;">
+  <ef-template-admin show-modal="true">
+    <div slot="content-left">
+      hola
+    </div>
+    <div slot="content-right">
+      hola, soy el componente modal right
+    </div>
+  </ef-template-admin>
 </body>
 
 </html>


### PR DESCRIPTION
Link card: XCH-110 [https://thecoderhouse.atlassian.net/browse/XCH-110]  y XCH-111[https://thecoderhouse.atlassian.net/browse/XCH-111]

Descripción: se realizo el template seccion admin y el componente modal right , se realizan en un mismo pr ya que los dos van unidos.

Como probar

1. repositorio every-framework-components
2. rama XCH-110
3. npm i && npm run start