### PR TITLE
XCH-74-EF-MODAL-CONFIRMATION

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -47,11 +47,24 @@ export namespace Components {
         "value": string;
     }
     interface EfModal {
-        "modal": boolean;
+        "showModal": boolean;
+        "width": string;
+    }
+    interface EfModalConfirmation {
+        "showModal": boolean;
+        "textCancel": string;
+        "textConfirmation": string;
+        "width": string;
+    }
+    interface EfModalRight {
+        "showModal": boolean;
         "width": string;
     }
     interface EfTabs {
         "titles": { text: string; value: string; icon?: string; slot?: (item: { [key: string]: string | number }) => JSX.Element }[];
+    }
+    interface EfTemplateAdmin {
+        "showModal": boolean;
     }
 }
 declare global {
@@ -97,11 +110,29 @@ declare global {
         prototype: HTMLEfModalElement;
         new (): HTMLEfModalElement;
     };
+    interface HTMLEfModalConfirmationElement extends Components.EfModalConfirmation, HTMLStencilElement {
+    }
+    var HTMLEfModalConfirmationElement: {
+        prototype: HTMLEfModalConfirmationElement;
+        new (): HTMLEfModalConfirmationElement;
+    };
+    interface HTMLEfModalRightElement extends Components.EfModalRight, HTMLStencilElement {
+    }
+    var HTMLEfModalRightElement: {
+        prototype: HTMLEfModalRightElement;
+        new (): HTMLEfModalRightElement;
+    };
     interface HTMLEfTabsElement extends Components.EfTabs, HTMLStencilElement {
     }
     var HTMLEfTabsElement: {
         prototype: HTMLEfTabsElement;
         new (): HTMLEfTabsElement;
+    };
+    interface HTMLEfTemplateAdminElement extends Components.EfTemplateAdmin, HTMLStencilElement {
+    }
+    var HTMLEfTemplateAdminElement: {
+        prototype: HTMLEfTemplateAdminElement;
+        new (): HTMLEfTemplateAdminElement;
     };
     interface HTMLElementTagNameMap {
         "ef-button": HTMLEfButtonElement;
@@ -111,7 +142,10 @@ declare global {
         "ef-dropdown": HTMLEfDropdownElement;
         "ef-input": HTMLEfInputElement;
         "ef-modal": HTMLEfModalElement;
+        "ef-modal-confirmation": HTMLEfModalConfirmationElement;
+        "ef-modal-right": HTMLEfModalRightElement;
         "ef-tabs": HTMLEfTabsElement;
+        "ef-template-admin": HTMLEfTemplateAdminElement;
     }
 }
 declare namespace LocalJSX {
@@ -160,11 +194,25 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     interface EfModal {
-        "modal"?: boolean;
+        "showModal"?: boolean;
+        "width"?: string;
+    }
+    interface EfModalConfirmation {
+        "onEvent"?: (event: CustomEvent<any>) => void;
+        "showModal"?: boolean;
+        "textCancel"?: string;
+        "textConfirmation"?: string;
+        "width"?: string;
+    }
+    interface EfModalRight {
+        "showModal"?: boolean;
         "width"?: string;
     }
     interface EfTabs {
         "titles"?: { text: string; value: string; icon?: string; slot?: (item: { [key: string]: string | number }) => JSX.Element }[];
+    }
+    interface EfTemplateAdmin {
+        "showModal"?: boolean;
     }
     interface IntrinsicElements {
         "ef-button": EfButton;
@@ -174,7 +222,10 @@ declare namespace LocalJSX {
         "ef-dropdown": EfDropdown;
         "ef-input": EfInput;
         "ef-modal": EfModal;
+        "ef-modal-confirmation": EfModalConfirmation;
+        "ef-modal-right": EfModalRight;
         "ef-tabs": EfTabs;
+        "ef-template-admin": EfTemplateAdmin;
     }
 }
 export { LocalJSX as JSX };
@@ -188,7 +239,10 @@ declare module "@stencil/core" {
             "ef-dropdown": LocalJSX.EfDropdown & JSXBase.HTMLAttributes<HTMLEfDropdownElement>;
             "ef-input": LocalJSX.EfInput & JSXBase.HTMLAttributes<HTMLEfInputElement>;
             "ef-modal": LocalJSX.EfModal & JSXBase.HTMLAttributes<HTMLEfModalElement>;
+            "ef-modal-confirmation": LocalJSX.EfModalConfirmation & JSXBase.HTMLAttributes<HTMLEfModalConfirmationElement>;
+            "ef-modal-right": LocalJSX.EfModalRight & JSXBase.HTMLAttributes<HTMLEfModalRightElement>;
             "ef-tabs": LocalJSX.EfTabs & JSXBase.HTMLAttributes<HTMLEfTabsElement>;
+            "ef-template-admin": LocalJSX.EfTemplateAdmin & JSXBase.HTMLAttributes<HTMLEfTemplateAdminElement>;
         }
     }
 }

--- a/src/components/ef-modal-confirmation/ef-modal-confirmation.css
+++ b/src/components/ef-modal-confirmation/ef-modal-confirmation.css
@@ -1,0 +1,29 @@
+.ef-modal-confirmation {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: 345px;
+  text-align: center;
+  font-family: 'Quicksand', sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 25px;
+  line-height: 20px;
+  text-align: center;
+  letter-spacing: 0.2px;
+  color: #000000;
+  padding: 10px;
+}
+.ef-modaL-confirmation__options {
+  padding: 20px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-around;
+  margin-top: 20%;
+  margin-bottom: -20%;
+  width: 100%;
+}

--- a/src/components/ef-modal-confirmation/ef-modal-confirmation.tsx
+++ b/src/components/ef-modal-confirmation/ef-modal-confirmation.tsx
@@ -1,0 +1,44 @@
+import { Component, h, Prop, Event, EventEmitter } from '@stencil/core';
+
+@Component({
+  tag: 'ef-modal-confirmation',
+  styleUrl: 'ef-modal-confirmation.css',
+  shadow: true,
+})
+export class EfModalConfirmation {
+  @Prop() showModal: boolean = false;
+  @Prop() width: string;
+  @Prop() textConfirmation: string = 'ACEPTAR';
+  @Prop() textCancel: string = 'CANCELAR';
+
+  //Event to emit any action from of parent
+  @Event() event: EventEmitter;
+  eventButton(confirmation: boolean) {
+    this.event.emit(confirmation);
+  }
+  render() {
+    return (
+      <ef-modal show-modal={this.showModal} width={this.width}>
+        <div class="ef-modal-confirmation">
+          <slot></slot>
+          <div class="ef-modaL-confirmation__options">
+            <ef-button
+              onEvent={() => {
+                this.eventButton(true);
+              }}
+              color="PRIMARY"
+              text={this.textConfirmation}
+            ></ef-button>
+            <ef-button
+              onEvent={() => {
+                this.eventButton(false);
+              }}
+              color="SECONDARY"
+              text={this.textCancel}
+            ></ef-button>
+          </div>
+        </div>
+      </ef-modal>
+    );
+  }
+}

--- a/src/components/ef-modal/ef-modal.tsx
+++ b/src/components/ef-modal/ef-modal.tsx
@@ -6,12 +6,12 @@ import { Component, Host, h, Prop } from '@stencil/core';
   shadow: true,
 })
 export class EfModal {
-  @Prop() modal: boolean = false;
+  @Prop() showModal: boolean = false;
   @Prop() width: string;
   render() {
     return (
       <Host>
-        <div class={this.modal ? 'wrapper visible' : 'wrapper'}>
+        <div class={this.showModal ? 'wrapper visible' : 'wrapper'}>
           <div class="modal" style={{ width: this.width }}>
             <slot />
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -33,7 +33,9 @@
 <body style="
 background-color: rgb(167, 164, 164);">
   <div style="display:flex;flex-direction:row;align-items:center;justify-content:space-around;height: 58vh;">
-    <ef-tabs></ef-tabs>
+    <ef-modal-confirmation show-modal="true">
+      <div>¿Deseas eliminar permanentemente <br> a Cristian Quintero de <br> la lista de usuarios?</div>
+    </ef-modal-confirmation>
   </div>
 </body>
 


### PR DESCRIPTION
Link Card: XCH-74 [https://thecoderhouse.atlassian.net/browse/XCH-74]

Descripcion: Componente generico con slot para modal de confirmacion.

como probar:

1. rama XCH-74
2. npm i && npm run build
3. npm run start "ejemplo en index"